### PR TITLE
Fixing latest tag not having the JFrog artifactory URL

### DIFF
--- a/.github/workflows/docker_build_push.yaml
+++ b/.github/workflows/docker_build_push.yaml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build_and_push_image:
-    # runs-on: ubuntu-latest
     runs-on: self-hosted
     steps:
       -
@@ -18,7 +17,8 @@ jobs:
         name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=xmix-docker-dev/grpcurl
+          REPOSITORY_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')
+          REGISTRY_PATH="${{ secrets.ARTIFACTORY_URL }}/xmix-docker-dev/${REPOSITORY_NAME}"
           VERSION=edge
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -27,14 +27,14 @@ jobs:
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
             VERSION=pr-${{ github.event.number }}
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="${REGISTRY_PATH}:${VERSION}"
           # TODO: Refine... was creating too many hashes
           # if [ "${{ github.event_name }}" = "push" ]; then
           #   TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           # fi
           # if we pushed a tag, we also want publish a new latest image
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS,${REGISTRY_PATH}:latest"
           fi
           echo "TAGS to build and push are ${TAGS}"
           echo ::set-output name=version::${VERSION}
@@ -59,7 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: "${{ secrets.ARTIFACTORY_URL }}/${{ steps.prep.outputs.tags }}"
+          tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}


### PR DESCRIPTION
Fixing issue where the `latest` tag wasn't being pushed correctly due to missing the JFrog URL in its tag.